### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: 'CI'
 on: [push, pull_request]
-    
+permissions:
+  contents: read
 
 jobs:
   validate:


### PR DESCRIPTION
Potential fix for [https://github.com/tigy32/Tycode/security/code-scanning/10](https://github.com/tigy32/Tycode/security/code-scanning/10)

To fix the problem, set a `permissions` block in the workflow restricting the GITHUB_TOKEN to read-only permissions on contents. This can be set at the root of the workflow (applies to all jobs), or for granularity at the job level, but root-level is sufficient and recommended unless there's a clear reason otherwise. Edit `.github/workflows/ci.yml` and insert the following under the `name:` key (after line 1 and before `on:`) or right after `on:` (but before `jobs:`), with correct YAML indentation. No new methods/imports/definitions are needed; just update the workflow YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
