### PR TITLE
Update Linux arch detection to support ARM64 in dev.sh

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -28,7 +28,11 @@ detect_platform() {
             fi
             ;;
         "Linux")
-            echo "linux-x64"
+            if [ "$arch" = "aarch64" ]; then
+                echo "linux-arm64"
+            else
+                echo "linux-x64"
+            fi
             ;;
         *)
             echo "unsupported"


### PR DESCRIPTION
- Added check for aarch64 architecture
- Returns linux-arm64 for ARM64 systems
- Falls back to linux-x64 for other architectures