### PR TITLE
Fix trailing whitespace in AI provider message formatting

### DIFF
--- a/tycode-core/src/ai/bedrock.rs
+++ b/tycode-core/src/ai/bedrock.rs
@@ -64,7 +64,7 @@ impl BedrockProvider {
                 match block {
                     ContentBlock::Text(text) => {
                         if !text.trim().is_empty() {
-                            content_blocks.push(BedrockContentBlock::Text(text.clone()));
+                            content_blocks.push(BedrockContentBlock::Text(text.trim().to_string()));
                         }
                     }
                     ContentBlock::ReasoningContent(reasoning) => {

--- a/tycode-core/src/ai/claude_code.rs
+++ b/tycode-core/src/ai/claude_code.rs
@@ -79,13 +79,13 @@ impl ClaudeCodeProvider {
                 match block {
                     ContentBlock::Text(text) => {
                         if !text.trim().is_empty() {
-                            content.push(ClaudeContentBlock::Text { text: text.clone() });
+                            content.push(ClaudeContentBlock::Text { text: text.trim().to_string() });
                         }
                     }
                     ContentBlock::ReasoningContent(reasoning) => {
                         if !reasoning.text.trim().is_empty() {
                             content.push(ClaudeContentBlock::Thinking {
-                                text: reasoning.text.clone(),
+                                text: reasoning.text.trim().to_string(),
                             });
                         }
                     }
@@ -102,7 +102,7 @@ impl ClaudeCodeProvider {
                                 tool_use_id: tool_result.tool_use_id.clone(),
                                 is_error: tool_result.is_error.then_some(true),
                                 content: vec![ClaudeToolResultContent::OutputText {
-                                    text: tool_result.content.clone(),
+                                    text: tool_result.content.trim().to_string(),
                                 }],
                             });
                         }

--- a/tycode-core/src/ai/openrouter.rs
+++ b/tycode-core/src/ai/openrouter.rs
@@ -559,7 +559,7 @@ fn create_user_message_content(
 fn create_tool_result_message(tool_result: &ToolResultData) -> OpenRouterMessage {
     OpenRouterMessage {
         role: "tool".to_string(),
-        content: Some(MessageContent::String(tool_result.content.clone())),
+        content: Some(MessageContent::String(tool_result.content.trim().to_string())),
         name: None,
         tool_call_id: Some(tool_result.tool_use_id.clone()),
         tool_calls: None,
@@ -633,7 +633,9 @@ fn process_assistant_message(message: &Message) -> Result<Vec<OpenRouterMessage>
     for block in message.content.blocks() {
         match block {
             ContentBlock::Text(text) => {
-                content_parts.push(text.clone());
+                if !text.trim().is_empty() {
+                    content_parts.push(text.trim().to_string());
+                }
             }
             ContentBlock::ReasoningContent(reason) => {
                 if let Some(raw_json) = &reason.raw_json {
@@ -678,11 +680,15 @@ fn extract_text_content(content: &Content) -> String {
     for block in content.blocks() {
         match block {
             ContentBlock::Text(text) => {
-                text_parts.push(text.clone());
+                if !text.trim().is_empty() {
+                    text_parts.push(text.trim().to_string());
+                }
             }
             ContentBlock::ReasoningContent(reasoning) => {
                 // Include reasoning as text for user messages
-                text_parts.push(format!("[Reasoning: {}]", reasoning.text));
+                if !reasoning.text.trim().is_empty() {
+                    text_parts.push(format!("[Reasoning: {}]", reasoning.text.trim()));
+                }
             }
             ContentBlock::ToolUse(_) | ContentBlock::ToolResult(_) => {
                 continue;


### PR DESCRIPTION
This fixes the ValidationException error from Bedrock (and potentially other providers) that occurs when assistant messages end with trailing whitespace.

The issue was in the message conversion logic for all three AI providers:
- bedrock.rs: Text blocks were checked for emptiness after trimming, but the untrimmed text was sent to the API
- claude_code.rs: Same issue for text, reasoning, and tool result content
- openrouter.rs: Same issue in assistant message processing and text extraction

All providers now trim text content before sending to prevent trailing whitespace from causing validation errors.

Fixes: Terminal error: ValidationException: The model returned the following errors: messages: final assistant content cannot end with trailing whitespace