### PR TITLE
Add per-message timings

### DIFF
--- a/tycode-cli/src/commands.rs
+++ b/tycode-cli/src/commands.rs
@@ -14,6 +14,19 @@ pub enum LocalCommandResult {
 
 pub fn handle_local_command(state: &mut State, input: &str) -> LocalCommandResult {
     match input.trim() {
+        "/timing" => {
+            state.show_timing = !state.show_timing;
+            LocalCommandResult::Handled {
+                msg: format!(
+                    "Timings: {}",
+                    if state.show_timing {
+                        "enabled"
+                    } else {
+                        "disabled"
+                    }
+                ),
+            }
+        }
         "/verbose" => {
             state.show_reasoning = !state.show_reasoning;
             LocalCommandResult::Handled {

--- a/tycode-cli/src/interactive_app.rs
+++ b/tycode-cli/src/interactive_app.rs
@@ -255,6 +255,22 @@ impl InteractiveApp {
             ChatEvent::ProfilesList { .. } => {
                 // CLI handles profiles via slash commands, ignore this event
             }
+            ChatEvent::TimingUpdate {
+                waiting_for_human,
+                ai_processing,
+                tool_execution,
+            } => {
+                let total = waiting_for_human + ai_processing + tool_execution;
+                if self.state.show_timing {
+                    self.formatter.print_system(&format!(
+                        "Timing => Human: {:.1}s, AI: {:.1}s, Tools: {:.1}s, Total: {:.1}s",
+                        waiting_for_human.as_secs_f64(),
+                        ai_processing.as_secs_f64(),
+                        tool_execution.as_secs_f64(),
+                        total.as_secs_f64(),
+                    ));
+                }
+            }
         }
         Ok(())
     }

--- a/tycode-cli/src/state.rs
+++ b/tycode-cli/src/state.rs
@@ -1,4 +1,5 @@
 #[derive(Default)]
 pub struct State {
     pub show_reasoning: bool,
+    pub show_timing: bool,
 }

--- a/tycode-core/src/chat/events.rs
+++ b/tycode-core/src/chat/events.rs
@@ -3,6 +3,7 @@ use crate::persistence::session::SessionMetadata;
 use crate::tools::tasks::TaskList;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
+use std::time::Duration;
 use tokio::sync::mpsc;
 
 /// `ChatEvent` are the messages sent from the actor - the output of the actor.
@@ -42,6 +43,11 @@ pub enum ChatEvent {
     },
     ProfilesList {
         profiles: Vec<String>,
+    },
+    TimingUpdate {
+        waiting_for_human: Duration,
+        ai_processing: Duration,
+        tool_execution: Duration,
     },
     Error(String),
 }


### PR DESCRIPTION
Introduce the /timing local command for CLI.

I found myself curious how long a specific message was taking to process, so I added a way for users to get this information out at the end of each user message.

If enabled, the /timing command enables you to get timings out at the end of each message. The aggregates still apply on /cost.

Example:

```
> can you just give me a one sentence summary of everything?
...
[System] Task completed [success=true]: Provided a single sentence summary of tycode-core: It is the core engine for an AI coding assistant that orchestrates Claude conversations through specialized agents, executes tools (file ops, builds, type analysis, sub-agents), manages workspaces with security, persists sessions, and integrates with MCP servers.

> /timing
[System] Timings: enabled

> can you just give me a one sentence summary of everything?
...
[System] Task completed [success=true]: Provided one sentence summary of tycode-core.
[System] Timing => Human: 6.6s, AI: 8.5s, Tools: 0.0s, Total: 15.1s

> /cost
[System] === Session Cost Summary ===
...
Time Spent:
  Waiting for human:   67.4s
  AI processing:      198.8s
  Tool execution:       0.1s
  Total session:      266.2s
```